### PR TITLE
Add formatter

### DIFF
--- a/k3s-versions.py
+++ b/k3s-versions.py
@@ -23,7 +23,6 @@ FILE = "k3s-versions.json"
 GITHUBRELEASES = "https://github.com/k3s-io/k3s/releases/tag/"
 REPO = "k3s-io/k3s"
 
-VERSIONSWITHRELEASENOTES = ["v1.24","v1.25","v1.26","v1.27","v1.28","latest","stable"]
 OUTPUTFILE = "data/k3s.json"
 
 def main():
@@ -69,12 +68,14 @@ def main():
 		version = {"name": key['name'], "version": key['latest'], "github-release-link": ghr }
 		k3sversions['k3s-versions'].append(version)
 
-		if key['name'] in VERSIONSWITHRELEASENOTES:
-			release = repo.get_release(key['latest'])
+		release = repo.get_release(key['latest'])
 
-			with open("data/"+key['latest']+".md", "w") as releasefile:
-				releasefile.write("<!-- " + release.published_at.strftime("%d/%m/%Y %H:%M:%S") + " -->\n")
-				releasefile.write(release.body)
+		with open("data/"+key['latest']+".md", "w") as releasefile:
+			releasefile.writelines(["---\n",
+										 f"version: {key['latest']}\n",
+										 f"releaseDate: {release.published_at.strftime('%d/%m/%Y %H:%M:%S')}\n",
+										 "---\n"])
+			releasefile.write(release.body)
 
 	g.close()
 

--- a/k3s-versions.py
+++ b/k3s-versions.py
@@ -62,7 +62,9 @@ def main():
 	g = Github(auth=auth)
 	repo = g.get_repo(REPO)
 
-	for key in data["data"]:
+	ordereddata = data["data"][:3] + sorted(data["data"][3:], key=lambda d: d['name'], reverse=True)
+
+	for key in ordereddata:
 		ghr = GITHUBRELEASES+key['latest']
 		version = {"name": key['name'], "version": key['latest'], "github-release-link": ghr }
 		k3sversions['k3s-versions'].append(version)


### PR DESCRIPTION
Closes #18 

It looks like:
```
---
version: v1.16.15+k3s1
releaseDate: 04/09/2020 03:08:11
---
This release updates Kubernetes to v1.16.15

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#v11615)

## Changes since v1.16.14+k3s1:
- **[Upgrade Kubernetes to v1.16.15](https://github.com/rancher/k3s/issues/2194)**

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
```

I've also added the order and it gets all the release notes even if they are empty. YOLO